### PR TITLE
Use buster PHP images for php 7.3

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,5 +1,12 @@
 ARG VERSION=7.3
-FROM my127/php:${VERSION}-fpm-stretch
+ARG BASEOS=stretch
+FROM my127/php:${VERSION}-fpm-${BASEOS}
+
+RUN apt-get update \
+ && apt-get install -y \
+  aspell \
+  ghostscript \
+ && rm -rf /var/lib/apt/lists/*
 
 # PHP: additional extensions
 # --------------------------

--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -1,5 +1,12 @@
 ARG VERSION=7.3
-FROM my127/php:${VERSION}-fpm-stretch-console
+ARG BASEOS=stretch
+FROM my127/php:${VERSION}-fpm-${BASEOS}-console
+
+RUN apt-get update \
+ && apt-get install -y \
+  aspell \
+  ghostscript \
+ && rm -rf /var/lib/apt/lists/*
 
 # PHP: additional extensions
 # --------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,14 +10,16 @@ services:
       dockerfile: base.Dockerfile
       args:
         VERSION: 7.2
+        BASEOS: stretch
 
-  php73-fpm-stretch-base:
-    image: my127/akeneo:7.3-fpm-stretch
+  php73-fpm-buster-base:
+    image: my127/akeneo:7.3-fpm-buster
     build:
       context: ./
       dockerfile: base.Dockerfile
       args:
         VERSION: 7.3
+        BASEOS: buster
 
   # Console Images
 
@@ -28,11 +30,13 @@ services:
       dockerfile: console.Dockerfile
       args:
         VERSION: 7.2
+        BASEOS: stretch
 
-  php73-fpm-stretch-console:
-    image: my127/akeneo:7.3-fpm-stretch-console
+  php73-fpm-buster-console:
+    image: my127/akeneo:7.3-fpm-buster-console
     build:
       context: ./
       dockerfile: console.Dockerfile
       args:
         VERSION: 7.3
+        BASEOS: buster


### PR DESCRIPTION
So ghostscript 9.27 can be installed for Akeneo 4.x

Relies on https://github.com/my127/docker-php/pull/30