### PR TITLE
Move MySQL 8 CLI installation to docker image from harness

### DIFF
--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -2,6 +2,8 @@ ARG VERSION=7.3
 ARG BASEOS=stretch
 FROM my127/php:${VERSION}-fpm-${BASEOS}-console
 
+ARG VERSION=7.3
+
 RUN apt-get update \
  && apt-get install -y \
   aspell \
@@ -11,6 +13,22 @@ RUN apt-get update \
   aspell-de \
   ghostscript \
  && rm -rf /var/lib/apt/lists/*
+
+# MySQL 8 client
+# --------------
+RUN if [ "$VERSION" != "7.2" ]; then \
+  apt-get update \
+  && apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    dirmngr \
+    gnupg2 \
+  && echo "deb https://repo.mysql.com/apt/debian/ buster mysql-8.0" > /etc/apt/sources.list.d/mysql.list \
+  && apt-key adv --keyserver eu.pool.sks-keyservers.net --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5 \
+  && apt-get update \
+  && apt-get install -y \
+    mysql-community-client \
+  && rm -rf /var/lib/apt/lists/*; \
+fi
 
 # PHP: additional extensions
 # --------------------------


### PR DESCRIPTION
Means we can remove https://github.com/inviqa/harness-base-php/blob/0.10.x/src/akeneo/docker/image/console/Dockerfile.twig#L12-L30 from the harness.

Also, import the GPG key different from the harness to try to improve reliability.