### PR TITLE
Create multi-platform images from separate builds

### DIFF
--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -22,11 +22,13 @@ RUN if [ "$VERSION" != "7.2" ]; then \
     apt-transport-https \
     dirmngr \
     gnupg2 \
-  && echo "deb https://repo.mysql.com/apt/debian/ buster mysql-8.0" > /etc/apt/sources.list.d/mysql.list \
+  && [ "$(uname -m)" = aarch64 ] || ( \
+  echo "deb https://repo.mysql.com/apt/debian/ buster mysql-8.0" > /etc/apt/sources.list.d/mysql.list \
   && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5 \
   && apt-get update \
   && apt-get install -y \
     mysql-community-client \
+  ) \
   && rm -rf /var/lib/apt/lists/*; \
 fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # Base Images
 
   php72-fpm-stretch-base:
-    image: my127/akeneo:7.2-fpm-stretch
+    image: my127/akeneo:7.2-fpm-stretch${TAG_SUFFIX:-}
     build:
       context: ./
       dockerfile: base.Dockerfile
@@ -13,7 +13,7 @@ services:
         BASEOS: stretch
 
   php73-fpm-buster-base:
-    image: my127/akeneo:7.3-fpm-buster
+    image: my127/akeneo:7.3-fpm-buster${TAG_SUFFIX:-}
     build:
       context: ./
       dockerfile: base.Dockerfile
@@ -22,7 +22,7 @@ services:
         BASEOS: buster
 
   php74-fpm-buster-base:
-    image: my127/akeneo:7.4-fpm-buster
+    image: my127/akeneo:7.4-fpm-buster${TAG_SUFFIX:-}
     build:
       context: ./
       dockerfile: base.Dockerfile
@@ -33,7 +33,7 @@ services:
   # Console Images
 
   php72-fpm-stretch-console:
-    image: my127/akeneo:7.2-fpm-stretch-console
+    image: my127/akeneo:7.2-fpm-stretch-console${TAG_SUFFIX:-}
     build:
       context: ./
       dockerfile: console.Dockerfile
@@ -42,7 +42,7 @@ services:
         BASEOS: stretch
 
   php73-fpm-buster-console:
-    image: my127/akeneo:7.3-fpm-buster-console
+    image: my127/akeneo:7.3-fpm-buster-console${TAG_SUFFIX:-}
     build:
       context: ./
       dockerfile: console.Dockerfile
@@ -51,7 +51,7 @@ services:
         BASEOS: buster
 
   php74-fpm-buster-console:
-    image: my127/akeneo:7.4-fpm-buster-console
+    image: my127/akeneo:7.4-fpm-buster-console${TAG_SUFFIX:-}
     build:
       context: ./
       dockerfile: console.Dockerfile

--- a/manifest-push.sh
+++ b/manifest-push.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+echo "${DOCKER_REGISTRY_CREDS_PSW}" | docker login --username "${DOCKER_REGISTRY_CREDS_USR}" --password-stdin docker.io
+
+for IMAGE in $(docker compose config --format json | jq -r '.services[].image'); do
+    docker manifest create "${IMAGE}" "${IMAGE}-linux-amd64" "${IMAGE}-linux-arm64"
+    docker manifest push "${IMAGE}"
+done


### PR DESCRIPTION
* Jenkins will build the images on separate runners for each platform, creating tags with the platform in, e.g.  my127/akeneo:7.4-fpm-buster-linux-arm64
* Those tags will be pushed to the docker registry
* Once all images built, manifests will be created for each service combining each platform using the original tags, e.g. my127/akeneo:7.4-fpm-buster
* The manifest tags will be pushed to the docker registry

Docker will pick the most platform relevant image layers when it pulls the original tag