### PR TITLE
Force a single build of php-73-fpm-stretch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
                 DOCKER_REGISTRY_CREDS = credentials('docker-registry-credentials')
             }
             when {
-                branch 'main'
+                branch 'feature/force-single-php73-stretch'
             }
             steps {
                 sh './manifest-push.sh'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,112 +3,22 @@ services:
 
   # Base Images
 
-  php72-fpm-stretch-base:
-    image: my127/akeneo:7.2-fpm-stretch${TAG_SUFFIX:-}
-    build:
-      context: ./
-      dockerfile: base.Dockerfile
-      args:
-        VERSION: 7.2
-        BASEOS: stretch
-
-  php73-fpm-buster-base:
-    image: my127/akeneo:7.3-fpm-buster${TAG_SUFFIX:-}
+  php73-fpm-stretch-base:
+    image: my127/akeneo:7.3-fpm-stretch${TAG_SUFFIX:-}
     build:
       context: ./
       dockerfile: base.Dockerfile
       args:
         VERSION: 7.3
-        BASEOS: buster
-
-  php74-fpm-buster-base:
-    image: my127/akeneo:7.4-fpm-buster${TAG_SUFFIX:-}
-    build:
-      context: ./
-      dockerfile: base.Dockerfile
-      args:
-        VERSION: 7.4
-        BASEOS: buster
-
-  php74-fpm-bullseye-base:
-    image: my127/akeneo:7.4-fpm-bullseye${TAG_SUFFIX:-}
-    build:
-      context: ./
-      dockerfile: base.Dockerfile
-      args:
-        VERSION: 7.4
-        BASEOS: bullseye
-
-  php80-fpm-bullseye-base:
-    image: my127/akeneo:8.0-fpm-bullseye${TAG_SUFFIX:-}
-    build:
-      context: ./
-      dockerfile: base.Dockerfile
-      args:
-        VERSION: "8.0"
-        BASEOS: bullseye
-
-  php81-fpm-bullseye-base:
-    image: my127/akeneo:8.1-fpm-bullseye${TAG_SUFFIX:-}
-    build:
-      context: ./
-      dockerfile: base.Dockerfile
-      args:
-        VERSION: 8.1
-        BASEOS: bullseye
+        BASEOS: stretch
 
   # Console Images
 
-  php72-fpm-stretch-console:
-    image: my127/akeneo:7.2-fpm-stretch-console${TAG_SUFFIX:-}
-    build:
-      context: ./
-      dockerfile: console.Dockerfile
-      args:
-        VERSION: 7.2
-        BASEOS: stretch
-
-  php73-fpm-buster-console:
-    image: my127/akeneo:7.3-fpm-buster-console${TAG_SUFFIX:-}
+  php73-fpm-stretch-console:
+    image: my127/akeneo:7.3-fpm-stretch-console${TAG_SUFFIX:-}
     build:
       context: ./
       dockerfile: console.Dockerfile
       args:
         VERSION: 7.3
-        BASEOS: buster
-
-  php74-fpm-buster-console:
-    image: my127/akeneo:7.4-fpm-buster-console${TAG_SUFFIX:-}
-    build:
-      context: ./
-      dockerfile: console.Dockerfile
-      args:
-        VERSION: 7.4
-        BASEOS: buster
-
-  php74-fpm-bullseye-console:
-    image: my127/akeneo:7.4-fpm-bullseye-console${TAG_SUFFIX:-}
-    build:
-      context: ./
-      dockerfile: console.Dockerfile
-      args:
-        VERSION: 7.4
-        BASEOS: bullseye
-
-  php80-fpm-bullseye-console:
-    image: my127/akeneo:8.0-fpm-bullseye-console${TAG_SUFFIX:-}
-    build:
-      context: ./
-      dockerfile: console.Dockerfile
-      args:
-        VERSION: "8.0"
-        BASEOS: bullseye
-
-  php81-fpm-bullseye-console:
-    image: my127/akeneo:8.1-fpm-bullseye-console${TAG_SUFFIX:-}
-    build:
-      context: ./
-      dockerfile: console.Dockerfile
-      args:
-        VERSION: 8.1
-        BASEOS: bullseye
+        BASEOS: stretch


### PR DESCRIPTION
We'll be obsoleting stretch but for some reason harness-base-php was using stretch for 7.3 when no build was in place