### PR TITLE
Obsolete stretch and PHP 7.2

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -1,5 +1,5 @@
-ARG VERSION=7.3
-ARG BASEOS=stretch
+ARG VERSION
+ARG BASEOS
 FROM my127/php:${VERSION}-fpm-${BASEOS}
 
 RUN apt-get update \

--- a/console.Dockerfile
+++ b/console.Dockerfile
@@ -3,8 +3,8 @@ ARG VERSION
 ARG BASEOS
 FROM my127/php:${VERSION}-fpm-${BASEOS}-console
 
-ARG VERSION=7.3
-ARG BASEOS=stretch
+ARG VERSION
+ARG BASEOS
 
 RUN apt-get update \
  && apt-get install -y \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,6 @@ services:
 
   # Base Images
 
-  php72-fpm-stretch-base:
-    image: my127/akeneo:7.2-fpm-stretch${TAG_SUFFIX:-}
-    build:
-      context: ./
-      dockerfile: base.Dockerfile
-      args:
-        VERSION: 7.2
-        BASEOS: stretch
-
   php73-fpm-buster-base:
     image: my127/akeneo:7.3-fpm-buster${TAG_SUFFIX:-}
     build:
@@ -76,15 +67,6 @@ services:
         BASEOS: bookworm
 
   # Console Images
-
-  php72-fpm-stretch-console:
-    image: my127/akeneo:7.2-fpm-stretch-console${TAG_SUFFIX:-}
-    build:
-      context: ./
-      dockerfile: console.Dockerfile
-      args:
-        VERSION: 7.2
-        BASEOS: stretch
 
   php73-fpm-buster-console:
     image: my127/akeneo:7.3-fpm-buster-console${TAG_SUFFIX:-}


### PR DESCRIPTION
Since Debian stretch is EOL, it's no longer receiving any package updates, and also for the associated PHP versions

PHP 7.2 Akeneo images were only built as stretch images, and so as also EOL they are removed as well

The previously built docker images on Docker Hub can remain